### PR TITLE
ci: update docker configurations and default ports

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@ DB_HOST=localhost
 DB_PORT=5432
 DB_NAME=sunmi_pos
 DB_USER=postgres
-DB_PASSWORD=your_password_here
+DB_PASSWORD=postgres
 
 # Database URL (for Docker)
 DATABASE_URL=postgres://postgres:postgres@postgres:5432/sunmi_pos
@@ -13,7 +13,7 @@ JWT_SECRET=your_jwt_secret_key_here
 JWT_EXPIRES_IN=24h
 
 # Server Configuration
-PORT=3000
+PORT=3001
 NODE_ENV=development
 
 # CORS Configuration
@@ -37,8 +37,8 @@ ADMIN_NAME=System Administrator
 BCRYPT_ROUNDS=10
 
 # API Configuration
-API_BASE_URL=http://localhost:3000/api
+API_BASE_URL=http://localhost:3001/api
 
 # Frontend Configuration
-VITE_API_URL=http://localhost:3000
-VITE_SOCKET_URL=http://localhost:3000
+VITE_API_URL=http://localhost:3001
+VITE_SOCKET_URL=http://localhost:3001

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -33,6 +33,7 @@ ENV DB_PORT=${DB_PORT:-5432}
 ENV DB_NAME=${DB_NAME:-sunmi_pos}
 ENV DB_USER=${DB_USER:-postgres}
 ENV DB_PASSWORD=${DB_PASSWORD:-postgres}
+ENV DOCKER_ENV=true
 
 # Ensure init-admin.js is properly copied and has correct permissions
 RUN mkdir -p /app/scripts

--- a/api/server.ts
+++ b/api/server.ts
@@ -6,7 +6,7 @@ import app, { server } from './app.js';
 /**
  * start server with port
  */
-const PORT = process.env.PORT || 3000;
+const PORT = process.env.PORT || 3001;
 
 // Start the HTTP server with Socket.io
 server.listen(PORT, () => {

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -9,6 +9,7 @@ services:
       POSTGRES_DB: sunmi_pos
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
+      DOCKER_ENV: 'true'
     ports:
       - "5433:5432"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,7 @@ services:
       - .env
     environment:
       - NODE_ENV=production
+      - DOCKER_ENV=true
       - PORT=${PORT:-3001}
       - DATABASE_URL=postgres://${DB_USER:-postgres}:${DB_PASSWORD:-postgres}@postgres:5432/${DB_NAME:-sunmi_pos}
       - API_BASE_URL=${API_BASE_URL:-http://localhost:3001/api}

--- a/scripts/init-admin.js
+++ b/scripts/init-admin.js
@@ -11,9 +11,9 @@ dotenv.config();
 // Create a PostgreSQL connection pool
 const pool = new pg.Pool({
   // In Docker environment, use postgres as host (service name)
-  host: process.env.NODE_ENV === 'production' ? 'postgres' : (process.env.DB_HOST || 'localhost'),
+  host: process.env.NODE_ENV === 'production' || process.env.DOCKER_ENV === 'true' ? 'postgres' : (process.env.DB_HOST || 'localhost'),
   // In Docker, PostgreSQL runs on standard port 5432
-  port: parseInt(process.env.NODE_ENV === 'production' ? '5432' : (process.env.DB_PORT || '5432')),
+  port: parseInt(process.env.NODE_ENV === 'production' || process.env.DOCKER_ENV === 'true' ? '5432' : (process.env.DB_PORT || '5432')),
   database: process.env.DB_NAME || 'sunmi_pos',
   user: process.env.DB_USER || 'postgres',
   password: process.env.DB_PASSWORD || 'postgres',


### PR DESCRIPTION
- Add DOCKER_ENV flag to docker-compose and Dockerfile
- Change default port from 3000 to 3001 across configurations
- Update database connection logic to consider DOCKER_ENV
- Simplify default password in .env.example for development